### PR TITLE
Benchmark comparison

### DIFF
--- a/cmd/ingress-perf.go
+++ b/cmd/ingress-perf.go
@@ -33,7 +33,7 @@ var cmd = &cobra.Command{
 }
 
 func run() *cobra.Command {
-	var cfg, uuid, baseUuid, esServer, esIndex, logLevel, baseIndex string
+	var cfg, uuid, baseUUID, esServer, esIndex, logLevel, baseIndex string
 	var cleanup bool
 	var tolerancy int
 	cmd := &cobra.Command{
@@ -56,7 +56,7 @@ func run() *cobra.Command {
 			if err := config.Load(cfg); err != nil {
 				return err
 			}
-			if baseUuid != "" && (tolerancy > 100 || tolerancy < 1) {
+			if baseUUID != "" && (tolerancy > 100 || tolerancy < 1) {
 				return fmt.Errorf("tolerancy is an integer between 1 and 100")
 			}
 			if esServer != "" {
@@ -71,7 +71,7 @@ func run() *cobra.Command {
 					return err
 				}
 			}
-			if err = runner.Start(uuid, baseUuid, baseIndex, tolerancy, indexer); err != nil {
+			if err = runner.Start(uuid, baseUUID, baseIndex, tolerancy, indexer); err != nil {
 				return err
 			}
 			if cleanup {
@@ -82,7 +82,7 @@ func run() *cobra.Command {
 	}
 	cmd.Flags().StringVarP(&cfg, "cfg", "c", "", "Configuration file")
 	cmd.Flags().StringVar(&uuid, "uuid", uid.NewV4().String(), "Benchmark uuid")
-	cmd.Flags().StringVar(&baseUuid, "baseline-uuid", "", "Baseline uuid to compare the results with")
+	cmd.Flags().StringVar(&baseUUID, "baseline-uuid", "", "Baseline uuid to compare the results with")
 	cmd.Flags().StringVar(&baseIndex, "baseline-index", "ingress-performance", "Baseline Elasticsearch index")
 	cmd.Flags().IntVar(&tolerancy, "tolerancy", 20, "Comparison tolerancy, must be an integer between 1 and 100")
 	cmd.Flags().StringVar(&esServer, "es-server", "", "Elastic Search endpoint")

--- a/cmd/ingress-perf.go
+++ b/cmd/ingress-perf.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/cloud-bulldozer/go-commons/indexers"
@@ -32,8 +33,9 @@ var cmd = &cobra.Command{
 }
 
 func run() *cobra.Command {
-	var cfg, uuid, esServer, esIndex, logLevel string
+	var cfg, uuid, baseUuid, esServer, esIndex, logLevel, baseIndex string
 	var cleanup bool
+	var tolerancy int
 	cmd := &cobra.Command{
 		Use:           "run",
 		Short:         "Run benchmark",
@@ -54,6 +56,9 @@ func run() *cobra.Command {
 			if err := config.Load(cfg); err != nil {
 				return err
 			}
+			if baseUuid != "" && (tolerancy > 100 || tolerancy < 1) {
+				return fmt.Errorf("tolerancy is an integer between 1 and 100")
+			}
 			if esServer != "" {
 				log.Infof("Creating %s indexer", indexers.ElasticIndexer)
 				indexerCfg := indexers.IndexerConfig{
@@ -66,7 +71,7 @@ func run() *cobra.Command {
 					return err
 				}
 			}
-			if err = runner.Start(uuid, indexer); err != nil {
+			if err = runner.Start(uuid, baseUuid, baseIndex, tolerancy, indexer); err != nil {
 				return err
 			}
 			if cleanup {
@@ -77,8 +82,11 @@ func run() *cobra.Command {
 	}
 	cmd.Flags().StringVarP(&cfg, "cfg", "c", "", "Configuration file")
 	cmd.Flags().StringVar(&uuid, "uuid", uid.NewV4().String(), "Benchmark uuid")
+	cmd.Flags().StringVar(&baseUuid, "baseline-uuid", "", "Baseline uuid to compare the results with")
+	cmd.Flags().StringVar(&baseIndex, "baseline-index", "ingress-performance", "Baseline Elasticsearch index")
+	cmd.Flags().IntVar(&tolerancy, "tolerancy", 20, "Comparison tolerancy, must be an integer between 1 and 100")
 	cmd.Flags().StringVar(&esServer, "es-server", "", "Elastic Search endpoint")
-	cmd.Flags().StringVar(&esIndex, "es-index", "ingress-performance", "Elastic Search index")
+	cmd.Flags().StringVar(&esIndex, "es-index", "ingress-performance", "Elasticsearch index")
 	cmd.Flags().BoolVar(&cleanup, "cleanup", true, "Cleanup benchmark assets")
 	cmd.Flags().StringVar(&logLevel, "loglevel", "info", "Log level. Allowed levels are error, info and debug")
 	cmd.MarkFlagRequired("cfg")

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cloud-bulldozer/ingress-perf
 go 1.19
 
 require (
-	github.com/cloud-bulldozer/go-commons v1.0.1
+	github.com/cloud-bulldozer/go-commons v1.0.2
 	github.com/openshift/api v0.0.0-20230414095907-0540dde8186d
 	github.com/openshift/client-go v0.0.0-20221019143426-16aed247da5c
 	github.com/satori/go.uuid v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,8 @@ github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWR
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloud-bulldozer/go-commons v1.0.1 h1:WLmRyQZrBokGyULExmSM/IMJu63LJdc4Q+ofFSD1IjM=
-github.com/cloud-bulldozer/go-commons v1.0.1/go.mod h1:yJ1b4WosXfRKVXoomu/gc5cRMSi3HQEzFFwVBPZszSg=
+github.com/cloud-bulldozer/go-commons v1.0.2 h1:CcafUZbPLT8dd+hEY5qGra6e+6qwZh57vshNn2eV6GI=
+github.com/cloud-bulldozer/go-commons v1.0.2/go.mod h1:yJ1b4WosXfRKVXoomu/gc5cRMSi3HQEzFFwVBPZszSg=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/pkg/runner/exec.go
+++ b/pkg/runner/exec.go
@@ -34,8 +34,8 @@ import (
 
 var lock = &sync.Mutex{}
 
-func runBenchmark(cfg config.Config, clusterMetadata ocpmetadata.ClusterMetadata) ([]interface{}, error) {
-	var benchmarkResult []interface{}
+func runBenchmark(cfg config.Config, clusterMetadata ocpmetadata.ClusterMetadata) ([]tools.Result, error) {
+	var benchmarkResult []tools.Result
 	var clientPods []corev1.Pod
 	var wg sync.WaitGroup
 	var ep string

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -47,7 +47,7 @@ var clientSet *kubernetes.Clientset
 var dynamicClient *dynamic.DynamicClient
 var orClientSet *openshiftrouteclientset.Clientset
 
-func Start(uuid, baseUuid, baseIndex string, tolerancy int, indexer *indexers.Indexer) error {
+func Start(uuid, baseUUID, baseIndex string, tolerancy int, indexer *indexers.Indexer) error {
 	var err error
 	var kubeconfig string
 	var benchmarkResult []tools.Result
@@ -107,11 +107,11 @@ func Start(uuid, baseUuid, baseIndex string, tolerancy int, indexer *indexers.In
 					return err
 				}
 				log.Info(msg)
-				if baseUuid != "" {
-					log.Infof("Comparing total_avg_rps with baseline: %v in index %s", baseUuid, baseIndex)
-					var totalAvgRps float64 = 0
+				if baseUUID != "" {
+					log.Infof("Comparing total_avg_rps with baseline: %v in index %s", baseUUID, baseIndex)
+					var totalAvgRps float64
 					query := fmt.Sprintf("uuid.keyword: %s AND config.termination.keyword: %s AND config.concurrency: %d AND config.connections: %d AND config.serverReplicas: %d AND config.path.keyword: \\%s",
-						baseUuid, cfg.Termination, cfg.Concurrency, cfg.Connections, cfg.ServerReplicas, cfg.Path)
+						baseUUID, cfg.Termination, cfg.Concurrency, cfg.Connections, cfg.ServerReplicas, cfg.Path)
 					log.Debugf("Query: %s", query)
 					for _, b := range benchmarkResult {
 						totalAvgRps += b.TotalAvgRps
@@ -132,9 +132,8 @@ func Start(uuid, baseUuid, baseIndex string, tolerancy int, indexer *indexers.In
 	}
 	if passed {
 		return nil
-	} else {
-		return fmt.Errorf("some comparisons failed")
 	}
+	return fmt.Errorf("some benchmark comparisons failed")
 }
 
 func Cleanup(timeout time.Duration) error {

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -16,13 +16,17 @@ package runner
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"time"
 
+	"github.com/cloud-bulldozer/go-commons/comparison"
 	"github.com/cloud-bulldozer/go-commons/indexers"
+
 	ocpmetadata "github.com/cloud-bulldozer/go-commons/ocp-metadata"
 	"github.com/cloud-bulldozer/ingress-perf/pkg/config"
+	"github.com/cloud-bulldozer/ingress-perf/pkg/runner/tools"
 	log "github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -43,10 +47,12 @@ var clientSet *kubernetes.Clientset
 var dynamicClient *dynamic.DynamicClient
 var orClientSet *openshiftrouteclientset.Clientset
 
-func Start(uuid string, indexer *indexers.Indexer) error {
+func Start(uuid, baseUuid, baseIndex string, tolerancy int, indexer *indexers.Indexer) error {
 	var err error
-	var result []interface{}
 	var kubeconfig string
+	var benchmarkResult []tools.Result
+	var comparator comparison.Comparator
+	passed := true
 	log.Info("Starting ingress-perf")
 	if os.Getenv("KUBECONFIG") != "" {
 		kubeconfig = os.Getenv("KUBECONFIG")
@@ -70,6 +76,9 @@ func Start(uuid string, indexer *indexers.Indexer) error {
 	if err != nil {
 		return err
 	}
+	if indexer != nil {
+		comparator = comparison.NewComparator(*indexers.ESClient, baseIndex)
+	}
 	if err := deployAssets(); err != nil {
 		return err
 	}
@@ -84,22 +93,48 @@ func Start(uuid string, indexer *indexers.Indexer) error {
 				return err
 			}
 		}
-		if result, err = runBenchmark(cfg, clusterMetadata); err != nil {
+		if benchmarkResult, err = runBenchmark(cfg, clusterMetadata); err != nil {
 			return err
 		}
 		if indexer != nil {
 			if !cfg.Warmup {
-				msg, err := (*indexer).Index(result, indexers.IndexingOpts{})
+				benchmarkResultDocuments := make([]interface{}, len(benchmarkResult))
+				for _, res := range benchmarkResult {
+					benchmarkResultDocuments = append(benchmarkResultDocuments, res)
+				}
+				msg, err := (*indexer).Index(benchmarkResultDocuments, indexers.IndexingOpts{})
 				if err != nil {
 					return err
 				}
 				log.Info(msg)
+				if baseUuid != "" {
+					log.Infof("Comparing total_avg_rps with baseline: %v in index %s", baseUuid, baseIndex)
+					var totalAvgRps float64 = 0
+					query := fmt.Sprintf("uuid.keyword: %s AND config.termination.keyword: %s AND config.concurrency: %d AND config.connections: %d AND config.serverReplicas: %d AND config.path.keyword: \\%s",
+						baseUuid, cfg.Termination, cfg.Concurrency, cfg.Connections, cfg.ServerReplicas, cfg.Path)
+					log.Debugf("Query: %s", query)
+					for _, b := range benchmarkResult {
+						totalAvgRps += b.TotalAvgRps
+					}
+					totalAvgRps = totalAvgRps / float64(len(benchmarkResult))
+					msg, err := comparator.Compare("total_avg_rps", query, comparison.Avg, totalAvgRps, tolerancy)
+					if err != nil {
+						log.Error(err.Error())
+						passed = false
+					} else {
+						log.Info(msg)
+					}
+				}
 			} else {
 				log.Info("Warmup is enabled, skipping indexing")
 			}
 		}
 	}
-	return nil
+	if passed {
+		return nil
+	} else {
+		return fmt.Errorf("some comparisons failed")
+	}
 }
 
 func Cleanup(timeout time.Duration) error {


### PR DESCRIPTION
### Description

Take advantage of the compare library included in go-commons.

Fixes: https://github.com/cloud-bulldozer/ingress-perf/issues/1


At the moment it compares the average across samples of `total_avg_rps`. We can include more comparisons like latency in the future.

Tests will fail until https://github.com/cloud-bulldozer/go-commons/pull/9 gets merged and included into a tag