### PR TITLE
Add tuningPatch configuration to all generated documents

### DIFF
--- a/pkg/runner/exec.go
+++ b/pkg/runner/exec.go
@@ -77,6 +77,7 @@ func runBenchmark(cfg config.Config, clusterMetadata ocpmetadata.ClusterMetadata
 			Timestamp:       ts,
 			ClusterMetadata: clusterMetadata,
 		}
+		result.Config.Tuning = currentTuning // It's usefult to index the current tunning configuration in the all benchmark's documents
 		log.Infof("Running sample %d/%d: %v", i, cfg.Samples, cfg.Duration)
 		for _, pod := range clientPods {
 			wg.Add(1)

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -46,6 +46,7 @@ var restConfig *rest.Config
 var clientSet *kubernetes.Clientset
 var dynamicClient *dynamic.DynamicClient
 var orClientSet *openshiftrouteclientset.Clientset
+var currentTuning string
 
 func Start(uuid, baseUUID, baseIndex string, tolerancy int, indexer *indexers.Indexer, cleanupAssets bool) error {
 	var err error
@@ -97,7 +98,8 @@ func Start(uuid, baseUUID, baseIndex string, tolerancy int, indexer *indexers.In
 			return err
 		}
 		if cfg.Tuning != "" {
-			if err = ApplyTunning(cfg.Tuning); err != nil {
+			currentTuning = cfg.Tuning
+			if err = applyTunning(cfg.Tuning); err != nil {
 				return err
 			}
 		}

--- a/pkg/runner/tuning.go
+++ b/pkg/runner/tuning.go
@@ -26,7 +26,7 @@ import (
 
 // ApplyTunning applies the given json merge patch to the default ingresscontroller CR
 // and then waits for the ingres-controller deployment reconciliation to take place
-func ApplyTunning(tuningPatch string) error {
+func applyTunning(tuningPatch string) error {
 	log.Infof("Applying tuning patch to ingress controller: %v", tuningPatch)
 	_, err := dynamicClient.Resource(schema.GroupVersionResource{
 		Group:    "operator.openshift.io",


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

Adding the "last known" tunintPatch to the indexed documents. This is useful to add another bucket in the visualizations, also allow to better track a single document w/o having to look at the first document indexed.

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
