### PR TITLE
Fix tag name logic and add BuildDate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 GIT_COMMIT = $(shell git rev-parse HEAD)
 
 BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
-ifeq ($(BRANCH),)
+ifeq ($(BRANCH),HEAD)
 	VERSION := $(shell git describe --tags --abbrev=0)
 else
-	VERSION := $(subst main,latest,$(BRANCH))
+	VERSION := $(BRANCH)
 endif
 
 BUILD_DATE = $(shell date '+%Y-%m-%d-%H:%M:%S')
@@ -23,7 +23,7 @@ all: lint build
 build: $(BIN_PATH)
 
 $(BIN_PATH): $(SOURCES)
-	GOARCH=$(go env GOARCH) CGO_ENABLED=$(CGO) go build -v -ldflags "-X $(INGRESS_PERF_VERSION).GitCommit=$(GIT_COMMIT) -X $(INGRESS_PERF_VERSION).Version=$(VERSION)" -o $(BIN_PATH) cmd/ingress-perf.go
+	GOARCH=$(go env GOARCH) CGO_ENABLED=$(CGO) go build -v -ldflags "-X $(INGRESS_PERF_VERSION).GitCommit=$(GIT_COMMIT) -X $(INGRESS_PERF_VERSION).Version=$(VERSION) -X $(INGRESS_PERF_VERSION).BuildDate=$(BUILD_DATE)" -o $(BIN_PATH) cmd/ingress-perf.go
 
 clean:
 	rm -Rf $(BIN_DIR)

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ all: lint build
 build: $(BIN_PATH)
 
 $(BIN_PATH): $(SOURCES)
-	GOARCH=$(go env GOARCH) CGO_ENABLED=$(CGO) go build -v -ldflags "-X $(INGRESS_PERF_VERSION).GitCommit=$(GIT_COMMIT) -X $(INGRESS_PERF_VERSION).Version=$(VERSION) -X $(INGRESS_PERF_VERSION).BuildDate=$(BUILD_DATE)" -o $(BIN_PATH) cmd/ingress-perf.go
+	GOARCH=$(shell go env GOARCH) CGO_ENABLED=$(CGO) go build -v -ldflags "-X $(INGRESS_PERF_VERSION).GitCommit=$(GIT_COMMIT) -X $(INGRESS_PERF_VERSION).Version=$(VERSION) -X $(INGRESS_PERF_VERSION).BuildDate=$(BUILD_DATE)" -o $(BIN_PATH) cmd/ingress-perf.go
 
 clean:
 	rm -Rf $(BIN_DIR)


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The previous implementation wasn't setting the tag name correctly, when git was in a tag, the output from `git rev-parse --abbrev-ref HEAD` was HEAD

```rsevilla@wonderland ~/labs/ingress-perf ((v0.2.5)) $ git rev-parse --abbrev-ref HEAD
HEAD
```

Also adding missing BuildDate argument to the build cmd

Example
```shell
rsevilla@wonderland ~/labs/ingress-perf ((v0.2.5)) $ make clean build
rm -Rf bin
GOARCH=amd64 CGO_ENABLED=0 go build -v -ldflags "-X github.com/cloud-bulldozer/ingress-perf/pkg/version.GitCommit=88f1d6511aa48eb6bb153cc546da8cf29812c804 -X github.com/cloud-bulldozer/ingress-perf/pkg/version.Version=main -X github.com/cloud-bulldozer/ingress-perf/pkg/version.BuildDate=2023-07-25-11:12:13" -o bin/ingress-perf cmd/ingress-perf.go
rsevilla@wonderland ~/labs/ingress-perf (main) $ ./bin/ingress-perf version
Version: main
Git Commit: 88f1d6511aa48eb6bb153cc546da8cf29812c804
Build Date: 2023-07-25-11:12:13
Go Version: go1.20.6
OS/Arch: linux amd64
```

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
