### PR TITLE
Local indexing

### DIFF
--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -78,7 +78,9 @@ func Start(uuid, baseUUID, baseIndex string, tolerancy int, indexer *indexers.In
 		return err
 	}
 	if indexer != nil {
-		comparator = comparison.NewComparator(*indexers.ESClient, baseIndex)
+		if _, ok := (*indexer).(*indexers.Elastic); ok {
+			comparator = comparison.NewComparator(*indexers.ESClient, baseIndex)
+		}
 	}
 	if err := deployAssets(); err != nil {
 		return err
@@ -109,11 +111,13 @@ func Start(uuid, baseUUID, baseIndex string, tolerancy int, indexer *indexers.In
 		}
 		if indexer != nil {
 			if !cfg.Warmup {
-				benchmarkResultDocuments := make([]interface{}, len(benchmarkResult))
+				var benchmarkResultDocuments []interface{}
 				for _, res := range benchmarkResult {
 					benchmarkResultDocuments = append(benchmarkResultDocuments, res)
 				}
-				msg, err := (*indexer).Index(benchmarkResultDocuments, indexers.IndexingOpts{})
+				msg, err := (*indexer).Index(benchmarkResultDocuments, indexers.IndexingOpts{
+					MetricName: uuid,
+				})
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Add flag to permit writing metrics to a local directory

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing

```shell
$ ./bin/ingress-perf run -c latency.yml --results-dir=ingress-perf-metrics --cleanup=false                                                                                                     
time="2023-08-07 18:10:00" level=info msg="Running ingress performance 07d6c2de-543e-4b30-92c0-ba01449f1f52" file="ingress-perf.go:67"                                                                                                        
time="2023-08-07 18:10:00" level=info msg="Creating local indexer" file="ingress-perf.go:84"                                                                                                                                                  
time="2023-08-07 18:10:00" level=info msg="Starting ingress-perf" file="runner.go:57"                                                                                                                                                         
time="2023-08-07 18:10:03" level=info msg="Deploying benchmark assets" file="runner.go:182"                                                                                                                                                   
time="2023-08-07 18:10:06" level=info msg="Running test 1/1 " file="runner.go:90"                                                                                                                                                             
time="2023-08-07 18:10:06" level=info msg="Tool:wrk termination:reencrypt servers:20 concurrency:18 procs:1 connections:800 duration:5s" file="runner.go:91"                                                                                  
time="2023-08-07 18:10:09" level=info msg="Running sample 1/2: 5s" file="exec.go:82"                                                                                                                                                          
time="2023-08-07 18:10:20" level=info msg="Summary for reencrypt: Rps=3424 avgLatency=3077 μs P99Latency=36285 μs" file="exec.go:91"                                                                                                          
time="2023-08-07 18:10:20" level=info msg="Running sample 2/2: 5s" file="exec.go:82"                                                                                                                                                          
time="2023-08-07 18:10:30" level=info msg="Summary for reencrypt: Rps=0 avgLatency=0 μs P99Latency=0 μs" file="exec.go:91"
time="2023-08-07 18:10:30" level=info msg="File ingress-perf-metrics/07d6c2de-543e-4b30-92c0-ba01449f1f52.json created with 2 documents" file="runner.go:125"

$ wc ingress-perf-metrics/07d6c2de-543e-4b30-92c0-ba01449f1f52.json  
    1     1 13311 ingress-perf-metrics/07d6c2de-543e-4b30-92c0-ba01449f1f52.json

```