### PR TITLE
Skip samples with any execution error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/net v0.10.0 // indirect
 	golang.org/x/oauth2 v0.8.0 // indirect
+	golang.org/x/sync v0.3.0
 	golang.org/x/sys v0.9.0 // indirect
 	golang.org/x/term v0.8.0 // indirect
 	golang.org/x/text v0.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
+github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/aws/aws-sdk-go v1.42.27/go.mod h1:OGr6lGMAKGlG9CVrYnWYDKIyb829c6EVBRjxqjmPepc=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -155,6 +157,8 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.3.0 h1:ftCYgMx6zT/asHUrPw8BLLscYtGznsLAnjq5RH9P66E=
+golang.org/x/sync v0.3.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -87,7 +87,7 @@ func Start(uuid, baseUUID, baseIndex string, tolerancy int, indexer *indexers.In
 	}
 	for i, cfg := range config.Cfg {
 		cfg.UUID = uuid
-		log.Infof("Running test %d/%d ", i+1, len(config.Cfg))
+		log.Infof("Running test %d/%d", i+1, len(config.Cfg))
 		log.Infof("Tool:%s termination:%v servers:%d concurrency:%d procs:%d connections:%d duration:%v",
 			cfg.Tool,
 			cfg.Termination,


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [x] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We should skip and not index samples with any kind of execution error

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing

After modifying the code to make it fail on purpose

```shell
$  ./bin/ingress-perf run -c config/standard.yml  --results-dir=ingress-perf          
time="2023-09-11 14:14:36" level=info msg="Running ingress performance b5816f56-5270-4afc-ac80-fd1c7c288cb9" file="ingress-perf.go:67"
time="2023-09-11 14:14:36" level=info msg="Creating local indexer" file="ingress-perf.go:84"                                                                                                                                                  
time="2023-09-11 14:14:36" level=info msg="Starting ingress-perf" file="runner.go:57"
time="2023-09-11 14:14:39" level=info msg="Deploying benchmark assets" file="runner.go:181"
time="2023-09-11 14:14:41" level=info msg="Running test 1/9" file="runner.go:90"
time="2023-09-11 14:14:41" level=info msg="Tool:wrk termination:http servers:90 concurrency:1 procs:1 connections:20 duration:1m0s" file="runner.go:91"
time="2023-09-11 14:14:43" level=info msg="Running sample 1/2: 1m0s" file="exec.go:84"
time="2023-09-11 14:14:45" level=error msg="Exec failed in pod ingress-perf-client-c8d5548c9-mvp5p: command terminated with exit code 255" file="exec.go:149"
time="2023-09-11 14:14:45" level=error msg="Errors found during execution, skipping sample" file="exec.go:96"
time="2023-09-11 14:14:45" level=info msg="Running sample 2/2: 1m0s" file="exec.go:84"                                
time="2023-09-11 14:14:46" level=error msg="Exec failed in pod ingress-perf-client-c8d5548c9-mvp5p: command terminated with exit code 255" file="exec.go:149"
time="2023-09-11 14:14:46" level=error msg="Errors found during execution, skipping sample" file="exec.go:96"
time="2023-09-11 14:14:46" level=info msg="Scenario summary http: Rps=NaN avgLatency=NaNms P99Latency=NaNms timeouts=0 http_errors=0" file="exec.go:113"
time="2023-09-11 14:14:46" level=info msg="Warmup is enabled, skipping indexing" file="runner.go:144"
time="2023-09-11 14:14:46" level=info msg="Running test 2/9" file="runner.go:90"
time="2023-09-11 14:14:46" level=info msg="Tool:wrk termination:http servers:90 concurrency:1 procs:2 connections:200 duration:2m0s" file="runner.go:91"
time="2023-09-11 14:14:49" level=info msg="Running sample 1/2: 2m0s" file="exec.go:84"
time="2023-09-11 14:14:50" level=error msg="Exec failed in pod ingress-perf-client-c8d5548c9-mvp5p: command terminated with exit code 255" file="exec.go:149"
time="2023-09-11 14:14:50" level=error msg="Exec failed in pod ingress-perf-client-c8d5548c9-mvp5p: command terminated with exit code 255" file="exec.go:149"
time="2023-09-11 14:14:50" level=error msg="Errors found during execution, skipping sample" file="exec.go:96"
time="2023-09-11 14:14:50" level=info msg="Running sample 2/2: 2m0s" file="exec.go:84"                                                                                                                                                        
time="2023-09-11 14:14:52" level=error msg="Exec failed in pod ingress-perf-client-c8d5548c9-mvp5p: command terminated with exit code 255" file="exec.go:149"
time="2023-09-11 14:14:52" level=error msg="Exec failed in pod ingress-perf-client-c8d5548c9-mvp5p: command terminated with exit code 255" file="exec.go:149"
time="2023-09-11 14:14:52" level=error msg="Errors found during execution, skipping sample" file="exec.go:96"
time="2023-09-11 14:14:52" level=info msg="Scenario summary http: Rps=NaN avgLatency=NaNms P99Latency=NaNms timeouts=0 http_errors=0" file="exec.go:113"
time="2023-09-11 14:14:52" level=info msg="File ingress-perf/b5816f56-5270-4afc-ac80-fd1c7c288cb9.json created with 0 documents" file="runner.go:124"
time="2023-09-11 14:14:52" level=info msg="Running test 3/9" file="runner.go:90"
time="2023-09-11 14:14:52" level=info msg="Tool:wrk termination:edge servers:90 concurrency:1 procs:2 connections:200 duration:2m0s" file="runner.go:91"
time="2023-09-11 14:14:54" level=info msg="Running sample 1/2: 2m0s" file="exec.go:84"
time="2023-09-11 14:14:56" level=error msg="Exec failed in pod ingress-perf-client-c8d5548c9-mvp5p: command terminated with exit code 255" file="exec.go:149"
time="2023-09-11 14:14:56" level=error msg="Exec failed in pod ingress-perf-client-c8d5548c9-mvp5p: command terminated with exit code 255" file="exec.go:149"
time="2023-09-11 14:14:56" level=error msg="Errors found during execution, skipping sample" file="exec.go:96"
time="2023-09-11 14:14:56" level=info msg="Running sample 2/2: 2m0s" file="exec.go:84" 

```
