### PR TITLE
Fix concurrent map writes panic

### DIFF
--- a/cmd/ingress-perf.go
+++ b/cmd/ingress-perf.go
@@ -23,7 +23,6 @@ import (
 	_ "github.com/cloud-bulldozer/ingress-perf/pkg/log"
 	"github.com/cloud-bulldozer/ingress-perf/pkg/runner"
 	uid "github.com/satori/go.uuid"
-	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -54,11 +53,11 @@ func run() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			lvl, err := logrus.ParseLevel(logLevel)
+			lvl, err := log.ParseLevel(logLevel)
 			if err != nil {
 				return err
 			}
-			logrus.SetLevel(lvl)
+			log.SetLevel(lvl)
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Fixing concurrent map writes panic that happens occasionally because we're reusing the same Tool instance for all goroutines.

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
