### PR TITLE
Skip ppc64le and s390x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,9 +34,9 @@ container-build:
 
 gha-build:
 	@echo "Building Multi-architecture container Images"
-	$(CONTAINER_BUILD) -f containers/Containerfile \
-	--platform=linux/amd64,linux/arm64,linux/ppc64le,linux/s390x \
-	-t $(CONTAINER_NS)/$(BIN_NAME) ./containers --manifest=$(CONTAINER_NS)/$(BIN_NAME):latest
+	$(CONTAINER_BUILD) --jobs=2 -f containers/Containerfile \
+	--platform=linux/amd64,linux/arm64 \
+	./containers --manifest=$(CONTAINER_NS)/$(BIN_NAME):latest
 
 gha-push: gha-build
 	@echo "Pushing Container Images"


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

We just need the arm64 and amd64 archs for now, let's skip the others, we can revisit the timeout issues in the future,  also removing incorrect `-t` flag in the build command that makes the command to fail.

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
