### PR TITLE
Fix check for replicas expression

### DIFF
--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -225,7 +225,7 @@ func reconcileNs(cfg config.Config) error {
 		if err != nil {
 			return err
 		}
-		if d.Spec.Replicas == &replicas {
+		if *d.Spec.Replicas == replicas {
 			return nil
 		}
 		deployment.Spec.Replicas = &replicas


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The expression to check the number of configured replicas is incorrect, it was checking the memory address rather than the value of the pointer, hence the condition wasn't never met.

In the example below the number of client replicas was 4 rather than 3 in the 2nd test
```
$ ./bin/ingress-perf run -c config/standard.yml
time="2023-10-24 09:27:41" level=info msg="Running ingress-perf (main@32f7bbc37f8bd27a3327c509b5640fc0c6f40cac) with uuid b4f36b32-5dd2-473e-9891-1ffef6e58764" file="ingress-perf.go:66"
time="2023-10-24 09:27:41" level=info msg="Creating local indexer" file="ingress-perf.go:83"
time="2023-10-24 09:27:45" level=info msg="HAProxy version: haproxy22-2.2.24-3.rhaos4.13.el8.x86_64" file="runner.go:81"
time="2023-10-24 09:27:45" level=info msg="Deploying benchmark assets" file="runner.go:186"
time="2023-10-24 09:27:47" level=info msg="Running test 1/8" file="runner.go:95"
time="2023-10-24 09:27:47" level=info msg="Tool:hloader termination:http servers:30 concurrency:3 procs:1 connections:200 duration:10s" file="runner.go:96"
time="2023-10-24 09:27:48" level=info msg="Waiting for replicas from deployment nginx in ns ingress-perf to be ready" file="runner.go:246"
time="2023-10-24 09:27:53" level=info msg="Waiting for replicas from deployment ingress-perf-client in ns ingress-perf to be ready" file="runner.go:246"
time="2023-10-24 09:27:56" level=info msg="Running sample 1/2: 10s" file="exec.go:73"
time="2023-10-24 09:28:08" level=info msg="http: Rps=44816 avgLatency=16ms P99Latency=51ms" file="exec.go:104"
time="2023-10-24 09:28:08" level=info msg="Sleeping for 5s" file="exec.go:107"
time="2023-10-24 09:28:13" level=info msg="Running sample 2/2: 10s" file="exec.go:73"
time="2023-10-24 09:28:25" level=info msg="http: Rps=51305 avgLatency=12ms P99Latency=57ms" file="exec.go:104"
time="2023-10-24 09:28:25" level=info msg="Sleeping for 5s" file="exec.go:107"
time="2023-10-24 09:28:30" level=info msg="Scenario summary http: Rps=48060 avgLatency=14ms P99Latency=54ms timeouts=0 http_errors=0" file="exec.go:112"
time="2023-10-24 09:28:30" level=info msg="File /tmp/hloader/b4f36b32-5dd2-473e-9891-1ffef6e58764.json created with 2 documents" file="runner.go:129"
time="2023-10-24 09:28:30" level=info msg="Running test 2/8" file="runner.go:95"
time="2023-10-24 09:28:30" level=info msg="Tool:hloader termination:edge servers:30 concurrency:4 procs:1 connections:200 duration:10s" file="runner.go:96"
time="2023-10-24 09:28:31" level=info msg="Waiting for replicas from deployment ingress-perf-client in ns ingress-perf to be ready" file="runner.go:246"
time="2023-10-24 09:28:34" level=info msg="Running sample 1/2: 10s" file="exec.go:73"
time="2023-10-24 09:28:46" level=info msg="edge: Rps=46110 avgLatency=19ms P99Latency=107ms" file="exec.go:104"
time="2023-10-24 09:28:46" level=info msg="Sleeping for 30s" file="exec.go:107"
time="2023-10-24 09:29:16" level=info msg="Running sample 2/2: 10s" file="exec.go:73"
time="2023-10-24 09:29:29" level=info msg="edge: Rps=46134 avgLatency=18ms P99Latency=88ms" file="exec.go:104"

```

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
