### PR TITLE
Print container status on reconcile timeout

### DIFF
--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -34,16 +34,16 @@ type Config struct {
 	Concurrency int32 `yaml:"concurrency" json:"concurrency"`
 	// Procs processes per client pod
 	Procs int `yaml:"procs" json:"procs"`
-	// Tool defines the tool to run the benchmark scenario
+	// Tool defines the tool to run the benchmark scenario. Example: wrk
 	Tool string `yaml:"tool" json:"tool"`
-	// ServerReplicas number of server (nginx) replicas backed by the routes. Example: wrk
+	// ServerReplicas number of server (nginx) replicas backed by the routes
 	ServerReplicas int32 `yaml:"serverReplicas" json:"serverReplicas"`
 	// Tuning defines a tuning patch for the default IngressController object
 	Tuning string `yaml:"tuningPatch" json:"tuningPatch"`
 	// Delay defines a delay between samples
-	Delay time.Duration `yaml:"delay"`
+	Delay time.Duration `yaml:"delay" json:"delay"`
 	// Warmup enables warmup: Indexing will be disabled in this scenario. Default is false
 	Warmup bool `yaml:"warmup" json:"-"`
 	// RequestTimeout defines the tool request timeout
-	RequestTimeout time.Duration `yaml:"requestTimeout"`
+	RequestTimeout time.Duration `yaml:"requestTimeout" json:"requestTimeout"`
 }

--- a/pkg/runner/exec.go
+++ b/pkg/runner/exec.go
@@ -92,7 +92,7 @@ func runBenchmark(cfg config.Config, clusterMetadata tools.ClusterMetadata) ([]t
 			}
 		}
 		if err = errGroup.Wait(); err != nil {
-			log.Error("Errors found during execution, skipping sample")
+			log.Errorf("Errors found during execution, skipping sample: %s", err)
 			continue
 		}
 		genResultSummary(&result)

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -32,6 +32,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
@@ -225,7 +226,7 @@ func reconcileNs(cfg config.Config) error {
 		if err != nil {
 			return err
 		}
-		if *d.Spec.Replicas == replicas {
+		if d.Status.ReadyReplicas == replicas {
 			return nil
 		}
 		deployment.Spec.Replicas = &replicas
@@ -243,9 +244,11 @@ func reconcileNs(cfg config.Config) error {
 
 func waitForDeployment(ns, deployment string, maxWaitTimeout time.Duration) error {
 	var errMsg string
+	var dep *appsv1.Deployment
+	var err error
 	log.Infof("Waiting for replicas from deployment %s in ns %s to be ready", deployment, ns)
-	err := wait.PollUntilContextTimeout(context.TODO(), time.Second, maxWaitTimeout, true, func(ctx context.Context) (bool, error) {
-		dep, err := clientSet.AppsV1().Deployments(ns).Get(context.TODO(), deployment, metav1.GetOptions{})
+	err = wait.PollUntilContextTimeout(context.TODO(), time.Second, maxWaitTimeout, true, func(ctx context.Context) (bool, error) {
+		dep, err = clientSet.AppsV1().Deployments(ns).Get(context.TODO(), deployment, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -259,6 +262,17 @@ func waitForDeployment(ns, deployment string, maxWaitTimeout time.Duration) erro
 	})
 	if err != nil && errMsg != "" {
 		log.Error(errMsg)
+		failedPods, _ := clientSet.CoreV1().Pods(ns).List(context.TODO(), metav1.ListOptions{
+			FieldSelector: "status.phase=Pending",
+			LabelSelector: labels.SelectorFromSet(dep.Spec.Selector.MatchLabels).String(),
+		})
+		for _, pod := range failedPods.Items {
+			for _, cs := range pod.Status.ContainerStatuses {
+				if cs.State.Waiting != nil {
+					log.Errorf("%v: %v", pod.Name, cs.State.Waiting.Message)
+				}
+			}
+		}
 	}
 	return err
 }

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -269,7 +269,7 @@ func waitForDeployment(ns, deployment string, maxWaitTimeout time.Duration) erro
 		for _, pod := range failedPods.Items {
 			for _, cs := range pod.Status.ContainerStatuses {
 				if cs.State.Waiting != nil {
-					log.Errorf("%v: %v", pod.Name, cs.State.Waiting.Message)
+					log.Errorf("%v@%v: %v", pod.Name, pod.Spec.NodeName, cs.State.Waiting.Message)
 				}
 			}
 		}


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

Printing the container statuses can be useful to help debugging failures on infrastructure deployment.
i.e:
```shell
time="2023-10-26 01:08:13" level=info msg="Running ingress-perf (debug-events@efc206d314b49017d7d09b6c1f64a3056ad20cd6) with uuid 3ebc2582-707b-432c-bc60-eaeefc91585d" file="ingress-perf.go:66"                                             
time="2023-10-26 01:08:16" level=info msg="HAProxy version: haproxy22-2.2.24-3.rhaos4.13.el8.x86_64" file="runner.go:82"                                                                                                                      
time="2023-10-26 01:08:16" level=info msg="Deploying benchmark assets" file="runner.go:187"                                                                                                                                                   
time="2023-10-26 01:08:19" level=info msg="Running test 1/9" file="runner.go:96"                                                                                                                                                              
time="2023-10-26 01:08:19" level=info msg="Tool:wrk termination:http servers:90 concurrency:1 procs:1 connections:20 duration:1m0s" file="runner.go:97"                                                                                       
time="2023-10-26 01:08:19" level=info msg="Waiting for replicas from deployment nginx in ns ingress-perf to be ready" file="runner.go:249"                                                                                                    
time="2023-10-26 01:08:24" level=error msg="0/90 replicas ready" file="runner.go:264"
time="2023-10-26 01:08:25" level=error msg="nginx-774cb99485-2c5wh: Back-off pulling image \"quay.io/cloud-bulldozer/ngissssnx:latest\"" file="runner.go:272"
time="2023-10-26 01:08:25" level=error msg="nginx-774cb99485-2cbsk: Back-off pulling image \"quay.io/cloud-bulldozer/ngissssnx:latest\"" file="runner.go:272"
time="2023-10-26 01:08:25" level=error msg="nginx-774cb99485-2cd6q: Back-off pulling image \"quay.io/cloud-bulldozer/ngissssnx:latest\"" file="runner.go:272"
time="2023-10-26 01:08:25" level=error msg="nginx-774cb99485-2rtzb: Back-off pulling image \"quay.io/cloud-bulldozer/ngissssnx:latest\"" file="runner.go:272"
time="2023-10-26 01:08:25" level=error msg="nginx-774cb99485-45t4t: Back-off pulling image \"quay.io/cloud-bulldozer/ngissssnx:latest\"" file="runner.go:272"
time="2023-10-26 01:08:25" level=error msg="nginx-774cb99485-4b87m: Back-off pulling image \"quay.io/cloud-bulldozer/ngissssnx:latest\"" file="runner.go:272"
time="2023-10-26 01:08:25" level=error msg="nginx-774cb99485-4lzpx: Back-off pulling image \"quay.io/cloud-bulldozer/ngissssnx:latest\"" file="runner.go:27
etc.
```

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
