### PR TITLE
Fix node CPU query and remove round

### DIFF
--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -51,8 +51,8 @@ type Config struct {
 }
 
 var prometheusQueries = map[string]string{
-	"avg_cpu_usage_router_pods":           "round(avg(avg_over_time(sum(irate(container_cpu_usage_seconds_total{name!='', namespace='openshift-ingress', pod=~'router-default.+'}[2m])) by (pod)[ELAPSED:]))*100, 1)/100",
-	"avg_memory_usage_router_pods_bytes":  "round(avg(avg_over_time(sum(container_memory_working_set_bytes{name!='', namespace='openshift-ingress', pod=~'router-default.+'}) by (pod)[ELAPSED:]))*100,1)/100",
-	"avg_cpu_usage_router_nodes":          `round(avg(avg_over_time(sum(irate(node_cpu_seconds_total{mode!~'idle|steal'}[2m]) and on (instance) label_replace(kube_pod_info{namespace='openshift-ingress'},'instance', '$1', 'node', '(.+)')) by (instance,mode)[ELAPSED:]))*100,1)/100`,
-	"avg_memory_usage_router_nodes_bytes": `round(avg(avg_over_time(sum(node_memory_MemTotal_bytes-node_memory_MemAvailable_bytes{mode!~'idle|steal'} and on (instance) label_replace(kube_pod_info{namespace='openshift-ingress'},'instance', '$1', 'node', '(.+)')) by (instance,mode)[ELAPSED:]))*100,1)/100`,
+	"avg_cpu_usage_router_pods":           "avg(avg_over_time(sum(irate(container_cpu_usage_seconds_total{name!='', namespace='openshift-ingress', pod=~'router-default.+'}[2m])) by (pod)[ELAPSED:]))",
+	"avg_memory_usage_router_pods_bytes":  "avg(avg_over_time(sum(container_memory_working_set_bytes{name!='', namespace='openshift-ingress', pod=~'router-default.+'}) by (pod)[ELAPSED:]))",
+	"avg_cpu_usage_router_nodes":          "avg(avg_over_time(sum(irate(node_cpu_seconds_total{mode!~'idle|steal'}[2m]) and on (instance) label_replace(kube_pod_info{namespace='openshift-ingress'},'instance', '$1', 'node', '(.+)')) by (instance)[ELAPSED:]))",
+	"avg_memory_usage_router_nodes_bytes": "avg(avg_over_time(sum(node_memory_MemTotal_bytes-node_memory_MemAvailable_bytes and on (instance) label_replace(kube_pod_info{namespace='openshift-ingress'},'instance', '$1', 'node', '(.+)')) by (instance)[ELAPSED:]))",
 }


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

It's not necessary to round the metrics as we're calculating the avg only from a few datapoints, also, removing incorrect mode aggregation from cpu node cpu usage calculation, (it was incorrectly averaging all modes)

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
