### PR TITLE
Standarize gateway API asset deployment

### DIFF
--- a/cmd/ingress-perf.go
+++ b/cmd/ingress-perf.go
@@ -43,8 +43,8 @@ var versionCmd = &cobra.Command{
 }
 
 func run() *cobra.Command {
-	var cfg, uuid, esServer, esIndex, logLevel, outputDir, igNamespace string
-	var cleanup, esInsecureSkipVerify, podMetrics, serviceMesh, gatewayAPI bool
+	var cfg, uuid, esServer, esIndex, logLevel, outputDir, igNamespace, gatewayLB, gwClassController string
+	var cleanup, podMetrics, serviceMesh, gatewayAPI, esInsecureSkipVerify bool
 	cmd := &cobra.Command{
 		Use:           "run",
 		Short:         "Run benchmark",
@@ -67,7 +67,7 @@ func run() *cobra.Command {
 				uuid, cleanup,
 				runner.WithIndexer(esServer, esIndex, outputDir, podMetrics, esInsecureSkipVerify),
 				runner.WithServiceMesh(serviceMesh, igNamespace),
-				runner.WithGatewayAPI(gatewayAPI),
+				runner.WithGatewayAPI(gatewayAPI, gatewayLB, gwClassController),
 			)
 			return r.Start()
 		},
@@ -81,9 +81,11 @@ func run() *cobra.Command {
 	cmd.Flags().BoolVar(&cleanup, "cleanup", true, "Cleanup benchmark assets")
 	cmd.Flags().BoolVar(&podMetrics, "pod-metrics", false, "Index per pod metrics")
 	cmd.Flags().StringVar(&logLevel, "loglevel", "info", "Log level. Allowed levels are error, info and debug")
-	cmd.Flags().StringVar(&igNamespace, "gw-ns", "istio-system", "Ingress gateway namespace")
 	cmd.Flags().BoolVar(&serviceMesh, "service-mesh", false, "Enable service mesh mode")
-	cmd.Flags().BoolVar(&gatewayAPI, "gateway-api", false, "Enable gateway api mode")
+	cmd.Flags().StringVar(&igNamespace, "gw-ns", "istio-system", "Ingress gateway namespace")
+	cmd.Flags().BoolVar(&gatewayAPI, "gw-api", false, "Enable gateway API mode")
+	cmd.Flags().StringVar(&gatewayLB, "gw-lb", "gateway", "Name of the load balancer service of the gateway pods")
+	cmd.Flags().StringVar(&gwClassController, "gw-class", "openshift.io/gateway-controller", "Gateway class controller name")
 	cmd.MarkFlagRequired("cfg")
 	return cmd
 }

--- a/cmd/ingress-perf.go
+++ b/cmd/ingress-perf.go
@@ -67,7 +67,7 @@ func run() *cobra.Command {
 				uuid, cleanup,
 				runner.WithIndexer(esServer, esIndex, outputDir, podMetrics, esInsecureSkipVerify),
 				runner.WithServiceMesh(serviceMesh, igNamespace),
-				runner.WithGatewayAPI(gatewayAPI, gatewayLB, gwClassController),
+				runner.WithGatewayAPI(gatewayAPI, igNamespace, gatewayLB, gwClassController),
 			)
 			return r.Start()
 		},

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -411,8 +411,8 @@ func waitForDeployment(ns, deployment string, maxWaitTimeout time.Duration) erro
 func waitForGateway(ns, gateway string, maxWaitTimeout time.Duration) error {
 	var err error
 	var gw *gwv1.Gateway
-	log.Infof("Waiting for gateway %s in ns %s to be programmed", gateway, ns)
-	err = wait.PollUntilContextTimeout(context.TODO(), time.Second, maxWaitTimeout, true, func(ctx context.Context) (bool, error) {
+	log.Infof("Waiting for gateway/%s in ns %s to be programmed", gateway, ns)
+	err = wait.PollUntilContextTimeout(context.TODO(), time.Second, maxWaitTimeout, true, func(_ context.Context) (bool, error) {
 		gw, err = hrClientSet.GatewayV1().Gateways(ns).Get(context.TODO(), gateway, metav1.GetOptions{})
 		if err != nil {
 			return false, err

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -333,7 +333,7 @@ func (r *Runner) deployAssets() error {
 			return err
 		}
 		log.Debugf("Creating HTTPRoute...")
-		_, err = hrClientSet.GatewayV1().HTTPRoutes(r.igNamespace).Create(context.TODO(), &httproutes, metav1.CreateOptions{})
+		_, err = hrClientSet.GatewayV1().HTTPRoutes(routesNamespace).Create(context.TODO(), &httproutes, metav1.CreateOptions{})
 		if err != nil && !errors.IsAlreadyExists(err) {
 			return err
 		}


### PR DESCRIPTION
## Type of change

- [x] Optimization

## Description

The current logic for gateway API is meant to [automatically provision the gateway pod ](https://istio.io/latest/docs/tasks/traffic-management/ingress/gateway-api/#automated-deployment), this is sometimes not optimal since turns out that this gateway deployment cannot be tuned due to operator reconciles.
So the idea of this PR is:
- To assume that there's a running gateway pod, in the namespace specified by `--gw-ns`
- The gateway is exposed by a load balancer service in the same namespace, specified by `--gw-lb`
- There's a gatewayclass controller available, specified by `--gw-class`

Also, it uses the gatewayv1 rather than gatewayv1beta of the client

With these changes a execution of a benchmark in a cluster with a running gateway pod in the openshift-ingress namespace and a gatewayclass would be:

```shell
./bin/ingress-perf run --gw-api -c standard.yml --gw-lb my-gateway --gw-ns openshift-ingress --gw-class=istio
time="2024-11-14 16:26:34" level=info msg="Running ingress-perf (standarize-gw-api@6cee97ba0f5945f88d2ecfa0321f71e8879067c2) with uuid fea8b45c-d9ce-4e27-9120-cdb0f8f0f812" file="ingress-perf.go:62"
time="2024-11-14 16:26:34" level=info msg="Creating local indexer" file="runner.go:86"
time="2024-11-14 16:26:40" level=info msg="HAProxy version: haproxy28-2.8.10-1.rhaos4.17.el9.x86_64" file="runner.go:161"
time="2024-11-14 16:26:40" level=info msg="Deploying benchmark assets" file="runner.go:252"
time="2024-11-14 16:26:40" level=info msg="Gateway API mode enabled" file="runner.go:257"
time="2024-11-14 16:26:42" level=info msg="Waiting for gateway gateway in ns openshift-ingress to be programmed" file="runner.go:403"
time="2024-11-14 16:26:43" level=info msg="Running test 1/2" file="runner.go:168"
time="2024-11-14 16:26:43" level=info msg="Tool:wrk termination:http servers:45 concurrency:18 procs:1 connections:200 duration:10s http2:false" file="runner.go:169"
time="2024-11-14 16:26:44" level=info msg="Running sample 1/2: 10s" file="exec.go:102"
time="2024-11-14 16:26:59" level=info msg="http: Rps=29699 avgLatency=118ms P95Latency=176ms" file="exec.go:149"
time="2024-11-14 16:26:59" level=info msg="Sleeping for 10s" file="exec.go:152"
time="2024-11-14 16:27:09" level=info msg="Running sample 2/2: 10s" file="exec.go:102"
```

## Related Tickets & Documents

- Related Issue #
- Closes #
