### PR TITLE
Added flag for configuring insecureSkipVerify for indexing metrics us…

### DIFF
--- a/cmd/ingress-perf.go
+++ b/cmd/ingress-perf.go
@@ -44,7 +44,7 @@ var versionCmd = &cobra.Command{
 
 func run() *cobra.Command {
 	var cfg, uuid, esServer, esIndex, logLevel, outputDir, igNamespace string
-	var cleanup, podMetrics, serviceMesh, gatewayAPI bool
+	var cleanup, esInsecureSkipVerify, podMetrics, serviceMesh, gatewayAPI bool
 	cmd := &cobra.Command{
 		Use:           "run",
 		Short:         "Run benchmark",
@@ -65,7 +65,7 @@ func run() *cobra.Command {
 			}
 			r := runner.New(
 				uuid, cleanup,
-				runner.WithIndexer(esServer, esIndex, outputDir, podMetrics),
+				runner.WithIndexer(esServer, esIndex, outputDir, podMetrics, esInsecureSkipVerify),
 				runner.WithServiceMesh(serviceMesh, igNamespace),
 				runner.WithGatewayAPI(gatewayAPI),
 			)
@@ -75,6 +75,7 @@ func run() *cobra.Command {
 	cmd.Flags().StringVarP(&cfg, "cfg", "c", "", "Configuration file")
 	cmd.Flags().StringVar(&uuid, "uuid", uid.NewV4().String(), "Benchmark uuid")
 	cmd.Flags().StringVar(&esServer, "es-server", "", "Elastic Search endpoint")
+	cmd.Flags().BoolVar(&esInsecureSkipVerify, "es-insecure-skip-verify", true, "Elastic Search insecure skip verify")
 	cmd.Flags().StringVar(&esIndex, "es-index", "ingress-performance", "Elasticsearch index")
 	cmd.Flags().StringVar(&outputDir, "output-dir", "output", "Store collected metrics in this directory")
 	cmd.Flags().BoolVar(&cleanup, "cleanup", true, "Cleanup benchmark assets")

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -66,7 +66,7 @@ func New(uuid string, cleanup bool, opts ...OptsFunctions) *Runner {
 	return r
 }
 
-func WithIndexer(esServer, esIndex, resultsDir string, podMetrics bool) OptsFunctions {
+func WithIndexer(esServer, esIndex, resultsDir string, podMetrics bool, esInsecureSkipVerify bool) OptsFunctions {
 	return func(r *Runner) {
 		if esServer != "" || resultsDir != "" {
 			var indexerCfg indexers.IndexerConfig
@@ -75,6 +75,7 @@ func WithIndexer(esServer, esIndex, resultsDir string, podMetrics bool) OptsFunc
 					Type:    indexers.ElasticIndexer,
 					Servers: []string{esServer},
 					Index:   esIndex,
+					InsecureSkipVerify: esInsecureSkipVerify,
 				}
 			} else if resultsDir != "" {
 				indexerCfg = indexers.IndexerConfig{


### PR DESCRIPTION
…ing ES

## Type of change

- [ ] Refactor
- [ ] New feature
- [ x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--- Describe your changes in detail -->

## Related Tickets & Documents

- Related Issue #https://github.com/cloud-bulldozer/ingress-perf/issues/76

## Checklist before requesting a review

- [ x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing

1. insecureSkipVerify can be configured via flag:

```
$ ./bin/ingress-perf run --help
Run benchmark

Usage:
   run [flags]

Flags:
  -c, --cfg string                Configuration file
      --cleanup                   Cleanup benchmark assets (default true)
      --es-index string           Elasticsearch index (default "ingress-performance")
      --es-insecure-skip-verify   Elastic Search insecure skip verify (default true)
      --es-server string          Elastic Search endpoint
      --gateway-api               Enable gateway api mode
      --gw-ns string              Ingress gateway namespace (default "istio-system")
  -h, --help                      help for run
      --loglevel string           Log level. Allowed levels are error, info and debug (default "info")
      --output-dir string         Store collected metrics in this directory (default "output")
      --pod-metrics               Index per pod metrics
      --service-mesh              Enable service mesh mode
      --uuid string               Benchmark uuid (default "32f6076b-41b1-4b38-bc05-d452af2e8161")
```

2. Run test with default es-skip-insecure-verify to true:

```
$ ./bin/ingress-perf run --es-index=ingress-perf-test --es-server=https://<user>:<passwprd>@quickstart-elastic.<domain> --cfg=examples/config.yml
time="2025-03-02 12:22:07" level=info msg="Running ingress-perf (main@1fe256c305aec37453d76114251d4866a5c7d89b) with uuid 83545e49-9d1a-4bf3-b5f8-969ade114da6" file="ingress-perf.go:62"
time="2025-03-02 12:22:07" level=info msg="Creating elastic indexer" file="runner.go:86"
time="2025-03-02 12:22:12" level=info msg="HAProxy version: haproxy28-2.8.5-2.rhaos4.16.el9.x86_64" file="runner.go:159"
time="2025-03-02 12:22:12" level=info msg="Deploying benchmark assets" file="runner.go:250"
time="2025-03-02 12:22:13" level=info msg="Running test 1/1" file="runner.go:166"
time="2025-03-02 12:22:13" level=info msg="Tool:wrk termination:edge servers:45 concurrency:1 procs:2 connections:200 duration:2m0s http2:false" file="runner.go:167"
time="2025-03-02 12:22:13" level=info msg="Waiting for replicas from deployment nginx in ns ingress-perf to be ready" file="runner.go:363"
time="2025-03-02 12:22:18" level=info msg="Running sample 1/1: 2m0s" file="exec.go:102"
time="2025-03-02 12:24:21" level=info msg="edge: Rps=44110 avgLatency=7ms P95Latency=21ms" file="exec.go:149"
time="2025-03-02 12:24:21" level=info msg="Sleeping for 10s" file="exec.go:152"
time="2025-03-02 12:26:44" level=info msg="Scenario summary edge: Rps=49241 avgLatency=10ms P95Latency=34ms timeouts=1 http_errors=0" file="exec.go:157"
time="2025-03-02 12:26:45" level=info msg="Indexing finished in 790ms: created=2" file="runner.go:223"
time="2025-03-02 12:26:45" level=info msg="Cleaning up resources" file="runner.go:228"
```

3. Run test with es-skip-insecure-verify to false:

```
$ ./bin/ingress-perf run --es-index=ingress-perf-test --es-server=https://<user>:<passwprd>@quickstart-elastic.<domain> --cfg=examples/config.yml --cfg=examples/config.yml --es-insecure-skip-verify=false
time="2025-03-02 12:30:24" level=info msg="Running ingress-perf (main@1fe256c305aec37453d76114251d4866a5c7d89b) with uuid 48878ed7-ebad-454d-858e-0a2c5f8b9905" file="ingress-perf.go:62"
time="2025-03-02 12:30:24" level=info msg="Creating elastic indexer" file="runner.go:86"
time="2025-03-02 12:30:24" level=fatal msg="ES health check failed: tls: failed to verify certificate: x509: certificate is valid for quickstart-es-http.elastic.es.local, quickstart-es-http, quickstart-es-http.elastic.svc, quickstart-es-http.elastic, quickstart-es-internal-http.elastic.svc, quickstart-es-internal-http.elastic, *.quickstart-es-default.elastic.svc, not quickstart-elastic.<domain>" file="runner.go:89" 
```

4. Test **before** the fix:

```
$ ingress-perf run --es-index=ingress-perf-test --es-server=https://<user>:<passwprd>@quickstart-elastic.<domain> --cfg=examples/config.yml --cfg=examples/config.yml
time="2025-03-02 12:32:35" level=info msg="Running ingress-perf (0.5.0@1fe256c305aec37453d76114251d4866a5c7d89b) with uuid 9884a5be-92bd-45f1-8caa-bcec609955aa" file="ingress-perf.go:62"
time="2025-03-02 12:32:35" level=info msg="Creating elastic indexer" file="runner.go:85"
time="2025-03-02 12:32:35" level=fatal msg="ES health check failed: tls: failed to verify certificate: x509: certificate is valid for quickstart-es-http.elastic.es.local, quickstart-es-http, quickstart-es-http.elastic.svc, quickstart-es-http.elastic, quickstart-es-internal-http.elastic.svc, quickstart-es-internal-http.elastic, *.quickstart-es-default.elastic.svc, not quickstart-elastic.<domain>" file="runner.go:88"
```
