### PR TITLE
Gateway API fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,11 @@ At the time of writing these lines only the `http` and `edge` terminations are s
 
 ## Gateway API
 
-Ingress-perf is compatible with the OpenShift implementation of the Gateway API. Pass the flag `--gateway-api` to enable it. When this flag specified, `ingress-perf` will create a Gateway object in the `openshift-ingress` namespace (required as the gateway objects contains references to the `router-certs-default` secrets in that namespace) and a HTTPRoute in the `ingress-perf` namespace.
+Ingress-perf is compatible with the OpenShift implementation of the Gateway API. Pass the flag `--gw-api` to enable it. When this flag specified, `ingress-perf` will create a Gateway object in the `openshift-ingress` namespace (required as this gateway object has references to the `router-certs-default` secret in the same namespace) and a HTTPRoute in the `ingress-perf` namespace.
 
-By default, the gateway is bound to the gateway class, `openshift-default`, which is the default one at the time of writing, but it can be overridden with the `--gw-class` flag.
+By default, the gateway uses the the gateway class `openshift-default`, default one at the time of writing this text. However it can be overridden with the `--gw-class` flag.
 
-At the time of writing these lines only the `http` and `edge` terminations are supported.
+Currently, only `http` and `edge` terminations are supported.
 
 ## Compile
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,9 @@ At the time of writing these lines only the `http` and `edge` terminations are s
 
 ## Gateway API
 
-Ingress-perf is compatible with the OpenShift implementation of the Gateway API, provided by OpenShift Service Mesh. To enable this, it is necessary to pass the flag `--gateway-api=true`. When this flag specified, `ingress-perf` will create its httproute in the `ingress-perf` namespace.
+Ingress-perf is compatible with the OpenShift implementation of the Gateway API. Pass the flag `--gateway-api` to enable it. When this flag specified, `ingress-perf` will create a Gateway object in the `openshift-ingress` namespace (required as the gateway objects contains references to the `router-certs-default` secrets in that namespace) and a HTTPRoute in the `ingress-perf` namespace.
+
+By default, the gateway is bound to the gateway class, `openshift-default`, which is the default one at the time of writing, but it can be overridden with the `--gw-class` flag.
 
 At the time of writing these lines only the `http` and `edge` terminations are supported.
 

--- a/cmd/ingress-perf.go
+++ b/cmd/ingress-perf.go
@@ -82,10 +82,10 @@ func run() *cobra.Command {
 	cmd.Flags().BoolVar(&podMetrics, "pod-metrics", false, "Index per pod metrics")
 	cmd.Flags().StringVar(&logLevel, "loglevel", "info", "Log level. Allowed levels are error, info and debug")
 	cmd.Flags().BoolVar(&serviceMesh, "service-mesh", false, "Enable service mesh mode")
-	cmd.Flags().StringVar(&igNamespace, "gw-ns", "istio-system", "Ingress gateway namespace")
+	cmd.Flags().StringVar(&igNamespace, "gw-ns", "openshift-ingress", "Ingress gateway namespace")
 	cmd.Flags().BoolVar(&gatewayAPI, "gw-api", false, "Enable gateway API mode")
 	cmd.Flags().StringVar(&gatewayLB, "gw-lb", "gateway", "Name of the load balancer service of the gateway pods")
-	cmd.Flags().StringVar(&gwClassController, "gw-class", "openshift.io/gateway-controller", "Gateway class controller name")
+	cmd.Flags().StringVar(&gwClassController, "gw-class", "openshift-default", "Gateway class controller name")
 	cmd.MarkFlagRequired("cfg")
 	return cmd
 }

--- a/cmd/ingress-perf.go
+++ b/cmd/ingress-perf.go
@@ -43,7 +43,7 @@ var versionCmd = &cobra.Command{
 }
 
 func run() *cobra.Command {
-	var cfg, uuid, esServer, esIndex, logLevel, outputDir, igNamespace, gatewayLB, gwClassController string
+	var cfg, uuid, esServer, esIndex, logLevel, outputDir, igNamespace, gwClassController string
 	var cleanup, podMetrics, serviceMesh, gatewayAPI, esInsecureSkipVerify bool
 	cmd := &cobra.Command{
 		Use:           "run",
@@ -67,7 +67,7 @@ func run() *cobra.Command {
 				uuid, cleanup,
 				runner.WithIndexer(esServer, esIndex, outputDir, podMetrics, esInsecureSkipVerify),
 				runner.WithServiceMesh(serviceMesh, igNamespace),
-				runner.WithGatewayAPI(gatewayAPI, igNamespace, gatewayLB, gwClassController),
+				runner.WithGatewayAPI(gatewayAPI, gwClassController),
 			)
 			return r.Start()
 		},
@@ -82,9 +82,8 @@ func run() *cobra.Command {
 	cmd.Flags().BoolVar(&podMetrics, "pod-metrics", false, "Index per pod metrics")
 	cmd.Flags().StringVar(&logLevel, "loglevel", "info", "Log level. Allowed levels are error, info and debug")
 	cmd.Flags().BoolVar(&serviceMesh, "service-mesh", false, "Enable service mesh mode")
-	cmd.Flags().StringVar(&igNamespace, "gw-ns", "openshift-ingress", "Ingress gateway namespace")
+	cmd.Flags().StringVar(&igNamespace, "gw-ns", "openshift-ingress", "Ingress gateway namespace, only applies to Service Mesh mode")
 	cmd.Flags().BoolVar(&gatewayAPI, "gw-api", false, "Enable gateway API mode")
-	cmd.Flags().StringVar(&gatewayLB, "gw-lb", "gateway", "Name of the load balancer service of the gateway pods")
 	cmd.Flags().StringVar(&gwClassController, "gw-class", "openshift-default", "Gateway class controller name")
 	cmd.MarkFlagRequired("cfg")
 	return cmd

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -108,17 +108,16 @@ func WithServiceMesh(enable bool, igNamespace string) OptsFunctions {
 	}
 }
 
-func WithGatewayAPI(enable bool, igNamespace, gwLb, gwClassController string) OptsFunctions {
+func WithGatewayAPI(enable bool, gwClassController string) OptsFunctions {
 	return func(r *Runner) {
 		if enable {
 			r.gatewayAPI = enable
-			r.gwLb = gwLb
 			r.gwClassController = gwClassController
-			r.igNamespace = igNamespace
+			r.igNamespace = openshiftIngress
 			config.PrometheusQueries["avg_cpu_usage_ingress_gateway_pods"] =
-				fmt.Sprintf("avg(avg_over_time(sum(irate(container_cpu_usage_seconds_total{name!='', namespace='%s', container='istio-proxy'}[2m])) by (pod)[ELAPSED:]))", igNamespace)
+				fmt.Sprintf("avg(avg_over_time(sum(irate(container_cpu_usage_seconds_total{name!='', namespace='%s', container='istio-proxy'}[2m])) by (pod)[ELAPSED:]))", openshiftIngress)
 			config.PrometheusQueries["avg_memory_usage_ingress_gateway_pods_bytes"] =
-				fmt.Sprintf("avg(avg_over_time(sum(container_memory_working_set_bytes{name!='', namespace='%s', container='istio-proxy'}) by (pod)[ELAPSED:]))", igNamespace)
+				fmt.Sprintf("avg(avg_over_time(sum(container_memory_working_set_bytes{name!='', namespace='%s', container='istio-proxy'}) by (pod)[ELAPSED:]))", openshiftIngress)
 		}
 	}
 }

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -352,8 +352,8 @@ func (r *Runner) deployAssets() error {
 		err = wait.PollUntilContextTimeout(context.TODO(), time.Second, time.Minute, true, func(_ context.Context) (bool, error) {
 			addrs, err := net.LookupHost(string(hr.Spec.Hostnames[0]))
 			log.Debugf("HTTP Route %s addresses: %v", hr.Spec.Hostnames[0], addrs)
-			if len(addrs) == 0 {
-				return false, err
+			if len(addrs) == 0 || err != nil {
+				return false, nil
 			}
 			return true, err
 		})

--- a/pkg/runner/types.go
+++ b/pkg/runner/types.go
@@ -31,10 +31,11 @@ import (
 )
 
 const (
-	serverImage = "quay.io/cloud-bulldozer/nginx:latest"
-	serverName  = "nginx"
-	clientImage = "quay.io/cloud-bulldozer/ingress-perf:latest"
-	clientName  = "ingress-perf-client"
+	serverImage      = "quay.io/cloud-bulldozer/nginx:latest"
+	serverName       = "nginx"
+	clientImage      = "quay.io/cloud-bulldozer/ingress-perf:latest"
+	clientName       = "ingress-perf-client"
+	openshiftIngress = "openshift-ingress"
 )
 
 type Runner struct {
@@ -44,7 +45,6 @@ type Runner struct {
 	cleanup           bool
 	serviceMesh       bool
 	gatewayAPI        bool
-	gwLb              string
 	igNamespace       string
 	gwClassController string
 }
@@ -55,7 +55,7 @@ var routesNamespace = benchmarkNs.Name
 var portNumber gwv1.PortNumber = 8080
 var tlsType gwv1.TLSModeType = "Terminate"
 var fromNamespaces gwv1.FromNamespaces = "All"
-var certsNamespace gwv1.Namespace = "openshift-ingress"
+var certsNamespace gwv1.Namespace = openshiftIngress
 var listenerHostName gwv1.Hostname
 var ingressDomain string
 
@@ -347,7 +347,7 @@ var virtualService = v1networking.VirtualService{
 var gateway = gwv1.Gateway{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "gateway",
-		Namespace: "openshift-ingress",
+		Namespace: openshiftIngress,
 	},
 	Spec: gwv1.GatewaySpec{
 		Listeners: []gwv1.Listener{

--- a/pkg/runner/types.go
+++ b/pkg/runner/types.go
@@ -55,6 +55,7 @@ var routesNamespace = benchmarkNs.Name
 var portNumber gwv1.PortNumber = 8080
 var tlsType gwv1.TLSModeType = "Terminate"
 var fromNamespaces gwv1.FromNamespaces = "All"
+var certsNamespace gwv1.Namespace = "openshift-ingress"
 var listenerHostName gwv1.Hostname
 var ingressDomain string
 
@@ -345,7 +346,8 @@ var virtualService = v1networking.VirtualService{
 
 var gateway = gwv1.Gateway{
 	ObjectMeta: metav1.ObjectMeta{
-		Name: "gateway",
+		Name:      "gateway",
+		Namespace: "openshift-ingress",
 	},
 	Spec: gwv1.GatewaySpec{
 		Listeners: []gwv1.Listener{
@@ -374,7 +376,8 @@ var gateway = gwv1.Gateway{
 					Mode: &tlsType,
 					CertificateRefs: []gwv1.SecretObjectReference{
 						{
-							Name: "router-certs-default",
+							Name:      "router-certs-default",
+							Namespace: &certsNamespace,
 						},
 					},
 				},


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

Some changes are required for ingress-perf to work with latest OCP implementation of API gateway. The more noticeable change is that the gateway pod(s) get automatically provisioned when a  gateway objecte is created.

### Fixes:

- Gateway class name updated to openshift-default
- By default, the gateway requires to be deployed in the openshift-ingress namespace, as it uses the certificates in the secret _router-certs-default_, for that reason I've defaulted the gw-ns flag to that value
- Gateway objects is now pruned along the the ingress-perf namespace on the cleanup stage
- The HTTPRoute object is now created after the Gateway as it holds a parent reference to it
- Ingress-perf checks the DNS resolution of the new wildcard domain provisioned automatically by the ingress-controller-operator when the Gateway gets created
- Wait a couple of minutes for the endpoints exposed by the gateway to work before benchmarking them

---

### Pending

- Remove the arbitrary 2 minutes sleep and find out other alternative
- Update and document these changes properly
- Gateway pod tuning: the gateway pods get provisioned when the gateway object is created, this pod by default has  very limited resources, we might want to increase them among other parameters before running the benchmark

cc @qiliRedHat

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
