### PR TITLE
Add NodePort service type support for benchmarking

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Ingress-perf configuration is defined in a YAML file, holding an array of the fo
 | `keepalive`      | `bool`           | Use HTTP keepalived connections                                                             | `true`        | `hloader`       |
 | `requestRate`    | `int`            | Number of requests per second                                                               | `0` (unlimited) | `hloader`     |
 | `http2`          | `bool`           | Use HTTP2 requests, when possible                                                           | `false`         | `hloader`     |
+| `serviceType`    | `string`         | Kubernetes service type. Allowed values are `""` (default, ClusterIP with Routes) and `nodeport`. | `""`      | `wrk`,`hloader` |
 
 ## Supported tools
 
@@ -89,6 +90,16 @@ It is expected that the gateway is already installed by using [gateway injection
 To enable the respective Service Mesh mode, pass the flag `--service-mesh=sidecar` or `--service-mesh=ambient`. When specified, `ingress-perf` will create its routes in the namespace specified by `--gw-ns` (default: `istio-system`), these routes point to the http2 port of the `istio-ingressgateway` service. 4 gateways and 1 virtualservice are created in the `ingress-perf` namespace.
 
 At the time of writing these lines only the `http` and `edge` terminations are supported.
+
+## NodePort
+
+Ingress-perf supports benchmarking through Kubernetes NodePort services, bypassing the ingress controller entirely. This measures the direct `node-ip:node-port → pod` data path.
+
+Set `serviceType: nodeport` in the benchmark configuration. Only `http` and `passthrough` terminations are supported. NodePort mode is incompatible with service mesh and gateway API modes.
+
+Each client pod is assigned a different worker node IP to target. When `concurrency` is greater than the number of worker nodes, multiple client pods will share the same node IP. When `concurrency` is less than the number of worker nodes, only a subset of nodes will receive traffic.
+
+See [examples/nodeport.yml](./examples/nodeport.yml) for a sample configuration.
 
 ## Gateway API
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ At the time of writing these lines only the `http` and `edge` terminations are s
 
 Ingress-perf supports benchmarking through Kubernetes NodePort services, bypassing the ingress controller entirely. This measures the direct `node-ip:node-port → pod` data path.
 
-Set `serviceType: nodeport` in the benchmark configuration. Only `http` and `passthrough` terminations are supported. NodePort mode is incompatible with service mesh and gateway API modes.
+Set `serviceType: nodeport` in the benchmark configuration. Only `http` and `passthrough` (https) terminations are supported. NodePort mode is incompatible with service mesh and gateway API modes.
 
 Each client pod is assigned a different worker node IP to target. When `concurrency` is greater than the number of worker nodes, multiple client pods will share the same node IP. When `concurrency` is less than the number of worker nodes, only a subset of nodes will receive traffic.
 

--- a/examples/nodeport.yml
+++ b/examples/nodeport.yml
@@ -1,0 +1,37 @@
+# vi: expandtab shiftwidth=2 softtabstop=2
+
+- termination: http
+  serviceType: nodeport
+  connections: 200
+  samples: 2
+  duration: 3m
+  path: /1024.html
+  concurrency: 18
+  tool: wrk
+  serverReplicas: 45
+  requestTimeout: 10s
+  delay: 10s
+
+- termination: passthrough
+  serviceType: nodeport
+  connections: 200
+  samples: 2
+  duration: 3m
+  path: /1024.html
+  concurrency: 18
+  tool: wrk
+  serverReplicas: 45
+  requestTimeout: 10s
+  delay: 10s
+
+- termination: passthrough
+  serviceType: nodeport
+  connections: 200
+  samples: 2
+  duration: 3m
+  path: /1024.html
+  concurrency: 18
+  tool: hloader
+  serverReplicas: 45
+  requestTimeout: 10s
+  http2: true

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -16,6 +16,12 @@ package config
 
 import "time"
 
+const (
+	ServiceTypeNodePort    = "nodeport"
+	TerminationHTTP        = "http"
+	TerminationPassthrough = "passthrough"
+)
+
 var Cfg []Config
 
 type Config struct {
@@ -52,6 +58,8 @@ type Config struct {
 	Keepalive bool `yaml:"keepalive" json:"keepalive"`
 	// Use HTTP2 protocol, if possible
 	HTTP2 bool `yaml:"http2" json:"http2"`
+	// ServiceType defines the Kubernetes service type. Allowed values are "" (default, ClusterIP with Routes) and "nodeport"
+	ServiceType string `yaml:"serviceType" json:"serviceType"`
 }
 
 var PrometheusQueries = map[string]string{

--- a/pkg/runner/exec.go
+++ b/pkg/runner/exec.go
@@ -17,6 +17,7 @@ package runner
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -49,36 +50,12 @@ func runBenchmark(
 	var timeouts, httpErrors int64
 	var benchmarkResult []tools.Result
 	var clientPods []corev1.Pod
-	var ep string
-	var host string
-	if isGatewayAPIEnabled {
-		hr, err := hrClientSet.GatewayV1beta1().HTTPRoutes(routesNamespace).
-			Get(context.TODO(), serverName, metav1.GetOptions{})
-		if err != nil {
-			return benchmarkResult, err
-		}
-		host = string(hr.Spec.Hostnames[0])
-	} else {
-		r, err := orClientSet.RouteV1().Routes(routesNamespace).
-			Get(context.TODO(), fmt.Sprintf("%s-%s", serverName, cfg.Termination), metav1.GetOptions{})
-		if err != nil {
-			return benchmarkResult, err
-		}
-		host = r.Spec.Host
-	}
-	protocol := "http"
-	if cfg.Termination != "http" {
-		protocol = "https"
-	}
-
-	ep = fmt.Sprintf("%s://%v%v", protocol, host, cfg.Path)
 	allClientPods, err := clientSet.CoreV1().Pods(benchmarkNs.Name).List(context.TODO(), metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("app=%s", clientName),
 	})
 	if err != nil {
 		return benchmarkResult, err
 	}
-	// Filter out pods in terminating state from the list
 	for _, p := range allClientPods.Items {
 		if p.DeletionTimestamp == nil {
 			clientPods = append(clientPods, p)
@@ -86,6 +63,10 @@ func runBenchmark(
 		if len(clientPods) == int(cfg.Concurrency) {
 			break
 		}
+	}
+	podEndpoints, err := resolveEndpoints(cfg, clientPods, isGatewayAPIEnabled)
+	if err != nil {
+		return benchmarkResult, err
 	}
 	ts := time.Now().UTC()
 	for i := 1; i <= cfg.Samples; i++ {
@@ -98,14 +79,14 @@ func runBenchmark(
 			ClusterMetadata: clusterMetadata,
 			InfraMetrics:    make(map[string]float64),
 		}
-		result.Config.Tuning = currentTuning // It's useful to index the current tuning patch in the all benchmark's documents
+		result.Config.Tuning = currentTuning
 		log.Infof("Running sample %d/%d: %v", i, cfg.Samples, cfg.Duration)
 		errGroup := errgroup.Group{}
 		for _, pod := range clientPods {
 			for i := 0; i < cfg.Procs; i++ {
 				func(p corev1.Pod) {
 					errGroup.Go(func() error {
-						tool, err := tools.New(cfg, ep)
+						tool, err := tools.New(cfg, podEndpoints[p.Name])
 						if err != nil {
 							return err
 						}
@@ -128,22 +109,26 @@ func runBenchmark(
 		aggP95Latency += result.P95Latency
 		timeouts += result.Timeouts
 		httpErrors += result.HTTPErrors
-		elapsed := fmt.Sprintf("%ds", int(time.Since(sampleTs).Seconds()))
-		for field, query := range config.PrometheusQueries {
-			promQuery := strings.ReplaceAll(query, "ELAPSED", elapsed)
-			log.Debugf("Running query: %s", promQuery)
-			value, err := p.Query(promQuery, time.Time{}.UTC())
-			if err != nil {
-				log.Errorf("Query error: %v", err)
-				continue
-			}
-			data, ok := value.(model.Vector)
-			if !ok {
-				log.Errorf("Unsupported result format: %s", value.Type().String())
-				continue
-			}
-			for _, vector := range data {
-				result.InfraMetrics[field] = float64(vector.Value)
+		if cfg.ServiceType == config.ServiceTypeNodePort {
+			log.Debug("Skipping infrastructure metrics collection for NodePort service type")
+		} else {
+			elapsed := fmt.Sprintf("%ds", int(time.Since(sampleTs).Seconds()))
+			for field, query := range config.PrometheusQueries {
+				promQuery := strings.ReplaceAll(query, "ELAPSED", elapsed)
+				log.Debugf("Running query: %s", promQuery)
+				value, err := p.Query(promQuery, time.Time{}.UTC())
+				if err != nil {
+					log.Errorf("Query error: %v", err)
+					continue
+				}
+				data, ok := value.(model.Vector)
+				if !ok {
+					log.Errorf("Unsupported result format: %s", value.Type().String())
+					continue
+				}
+				for _, vector := range data {
+					result.InfraMetrics[field] = float64(vector.Value)
+				}
 			}
 		}
 		log.Infof("%s: Rps=%.0f avgLatency=%.0fms P95Latency=%.0fms", cfg.Termination, result.TotalAvgRps, result.AvgLatency/1e3, result.P95Latency/1e3)
@@ -215,6 +200,87 @@ func exec(ctx context.Context, tool tools.Tool, pod corev1.Pod, result *tools.Re
 	lock.Unlock()
 	log.Debugf("%s: avgRps: %.0f avgLatency: %.0f ms", podResult.Name, podResult.AvgRps, podResult.AvgLatency/1000)
 	return nil
+}
+
+func resolveEndpoints(cfg config.Config, clientPods []corev1.Pod, isGatewayAPIEnabled bool) (map[string]string, error) {
+	endpoints := make(map[string]string)
+	protocol := config.TerminationHTTP
+	if cfg.Termination != config.TerminationHTTP {
+		protocol = "https"
+	}
+	if cfg.ServiceType == config.ServiceTypeNodePort {
+		svc, err := clientSet.CoreV1().Services(benchmarkNs.Name).Get(context.TODO(), serverName, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		targetPort := config.TerminationHTTP
+		if cfg.Termination == config.TerminationPassthrough {
+			targetPort = "https"
+		}
+		var nodePort int32
+		for _, p := range svc.Spec.Ports {
+			if p.Name == targetPort {
+				nodePort = p.NodePort
+				break
+			}
+		}
+		if nodePort == 0 {
+			return nil, fmt.Errorf("no NodePort allocated for port %s", targetPort)
+		}
+		nodeIPs, err := getWorkerNodeIPs()
+		if err != nil {
+			return nil, err
+		}
+		if len(nodeIPs) == 0 {
+			return nil, errors.New("no worker node IPs found")
+		}
+		for i, pod := range clientPods {
+			ip := nodeIPs[i%len(nodeIPs)]
+			endpoints[pod.Name] = fmt.Sprintf("%s://%s:%d%s", protocol, ip, nodePort, cfg.Path)
+		}
+		log.Infof("NodePort %d, targeting %d worker nodes", nodePort, len(nodeIPs))
+	} else {
+		var host string
+		if isGatewayAPIEnabled {
+			hr, err := hrClientSet.GatewayV1beta1().HTTPRoutes(routesNamespace).
+				Get(context.TODO(), serverName, metav1.GetOptions{})
+			if err != nil {
+				return nil, err
+			}
+			host = string(hr.Spec.Hostnames[0])
+		} else {
+			r, err := orClientSet.RouteV1().Routes(routesNamespace).
+				Get(context.TODO(), fmt.Sprintf("%s-%s", serverName, cfg.Termination), metav1.GetOptions{})
+			if err != nil {
+				return nil, err
+			}
+			host = r.Spec.Host
+		}
+		ep := fmt.Sprintf("%s://%v%v", protocol, host, cfg.Path)
+		for _, pod := range clientPods {
+			endpoints[pod.Name] = ep
+		}
+	}
+	return endpoints, nil
+}
+
+func getWorkerNodeIPs() ([]string, error) {
+	nodes, err := clientSet.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{
+		LabelSelector: "node-role.kubernetes.io/worker,!node-role.kubernetes.io/infra",
+	})
+	if err != nil {
+		return nil, err
+	}
+	var ips []string
+	for _, node := range nodes.Items {
+		for _, addr := range node.Status.Addresses {
+			if addr.Type == corev1.NodeInternalIP {
+				ips = append(ips, addr.Address)
+				break
+			}
+		}
+	}
+	return ips, nil
 }
 
 func normalizeResults(result *tools.Result) {

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -323,7 +323,14 @@ func (r *Runner) deployAssets() error {
 		service.Spec.Type = corev1.ServiceTypeClusterIP
 	}
 	_, err = clientSet.CoreV1().Services(benchmarkNs.Name).Create(context.TODO(), &service, metav1.CreateOptions{})
-	if err != nil && !errors.IsAlreadyExists(err) {
+	if errors.IsAlreadyExists(err) {
+		if err := clientSet.CoreV1().Services(benchmarkNs.Name).Delete(context.TODO(), service.Name, metav1.DeleteOptions{}); err != nil {
+			return err
+		}
+		if _, err := clientSet.CoreV1().Services(benchmarkNs.Name).Create(context.TODO(), &service, metav1.CreateOptions{}); err != nil {
+			return err
+		}
+	} else if err != nil {
 		return err
 	}
 	if nodePort {

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -16,6 +16,7 @@ package runner
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"net"
 	"os"
@@ -30,6 +31,7 @@ import (
 	"github.com/cloud-bulldozer/ingress-perf/pkg/runner/tools"
 	log "github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -169,6 +171,29 @@ func (r *Runner) Start() error {
 	} else {
 		log.Infof("HAProxy version: %s", clusterMetadata.HAProxyVersion)
 	}
+	hasNP, hasNonNP := false, false
+	for _, cfg := range config.Cfg {
+		if cfg.ServiceType != "" && cfg.ServiceType != config.ServiceTypeNodePort {
+			return fmt.Errorf("unsupported serviceType %q, allowed values are \"\" and %q", cfg.ServiceType, config.ServiceTypeNodePort)
+		}
+		if cfg.ServiceType == config.ServiceTypeNodePort {
+			hasNP = true
+			if r.serviceMesh != "" {
+				return stderrors.New("serviceType nodeport is incompatible with service mesh mode")
+			}
+			if r.gatewayAPI {
+				return stderrors.New("serviceType nodeport is incompatible with gateway API mode")
+			}
+			if cfg.Termination != config.TerminationHTTP && cfg.Termination != config.TerminationPassthrough {
+				return fmt.Errorf("serviceType nodeport only supports http and passthrough terminations, got %s", cfg.Termination)
+			}
+		} else {
+			hasNonNP = true
+		}
+	}
+	if hasNP && hasNonNP {
+		return stderrors.New("mixing nodeport and non-nodeport service types in the same config is not supported")
+	}
 	if err := r.deployAssets(); err != nil {
 		return err
 	}
@@ -290,9 +315,22 @@ func (r *Runner) deployAssets() error {
 	if err != nil && !errors.IsAlreadyExists(err) {
 		return err
 	}
+	nodePort := hasNodePort()
+	if nodePort {
+		log.Info("NodePort service mode enabled")
+		service.Spec.Type = corev1.ServiceTypeNodePort
+	} else {
+		service.Spec.Type = corev1.ServiceTypeClusterIP
+	}
 	_, err = clientSet.CoreV1().Services(benchmarkNs.Name).Create(context.TODO(), &service, metav1.CreateOptions{})
 	if err != nil && !errors.IsAlreadyExists(err) {
 		return err
+	}
+	if nodePort {
+		// NodePort mode bypasses the ingress controller entirely — no Routes, Istio
+		// gateways, or Gateway API resources are needed. Start() validates that
+		// nodeport is not combined with service-mesh or gateway-api modes.
+		return nil
 	}
 	if !r.gatewayAPI {
 		for _, route := range routes {
@@ -429,6 +467,15 @@ func waitForDeployment(ns, deployment string, maxWaitTimeout time.Duration) erro
 		}
 	}
 	return err
+}
+
+func hasNodePort() bool {
+	for _, cfg := range config.Cfg {
+		if cfg.ServiceType == config.ServiceTypeNodePort {
+			return true
+		}
+	}
+	return false
 }
 
 func waitForGateway(ns, gateway string, maxWaitTimeout time.Duration) error {


### PR DESCRIPTION
Adds a new serviceType config field that allows benchmarking traffic through NodePort services, bypassing the ingress controller entirely. This measures the node-ip:node-port to pod data path.

- Support http and passthrough terminations for NodePort
- Distribute client pods across worker node IPs
- Skip router Prometheus metrics for NodePort scenarios
- Validate incompatible combos (service-mesh, gateway-api, edge/reencrypt)
- Extract endpoint resolution into dedicated function
- Add nodeport.yml example config and update README

Assisted-by: Claude

